### PR TITLE
Issue #9: [4] Navigation handling for specific use cases

### DIFF
--- a/src/boot/route-guards.ts
+++ b/src/boot/route-guards.ts
@@ -1,6 +1,8 @@
 import { boot } from 'quasar/wrappers'
+import { abortOnStartLocationGuard } from 'src/route-guards/abort-on-start-location.guard'
 import { checkSession } from 'src/route-guards/session-check.guard'
 
 export default boot(({ router }) => {
   router.beforeEach(checkSession)
+  router.afterEach(abortOnStartLocationGuard(router))
 })

--- a/src/boot/route-guards.ts
+++ b/src/boot/route-guards.ts
@@ -1,8 +1,8 @@
 import { boot } from 'quasar/wrappers'
 import { abortOnStartLocationGuard } from 'src/route-guards/abort-on-start-location.guard'
-import { checkSession } from 'src/route-guards/session-check.guard'
+import { sessionGuard } from 'src/route-guards/session.guard'
 
 export default boot(({ router }) => {
-  router.beforeEach(checkSession)
+  router.beforeEach(sessionGuard)
   router.afterEach(abortOnStartLocationGuard(router))
 })

--- a/src/pages/DiscordAuthCallbackPage.vue
+++ b/src/pages/DiscordAuthCallbackPage.vue
@@ -8,7 +8,12 @@
 import { getLogger } from 'src/boot/pino-logger'
 import { useApi } from 'src/composables/use-api.composable'
 import { defineComponent, onMounted } from 'vue'
-import { isNavigationFailure, useRoute, useRouter } from 'vue-router'
+import {
+  isNavigationFailure,
+  NavigationFailureType,
+  useRoute,
+  useRouter,
+} from 'vue-router'
 
 const LOGGER = getLogger('page:DiscordAuthCallbackPage')
 
@@ -41,7 +46,11 @@ export default defineComponent({
             name: 'index',
           })
 
-      if (isNavigationFailure(await navResult)) {
+      if (isNavigationFailure(await navResult, NavigationFailureType.aborted)) {
+        /*
+         * This will trigger if one of the navigations above were aborted.
+         * This handling will prevent the user from being stuck in the callback's UI.
+         */
         LOGGER.warn(
           'Navigation failure encountered, redirecting to the index as fallback'
         )

--- a/src/pages/DiscordAuthCallbackPage.vue
+++ b/src/pages/DiscordAuthCallbackPage.vue
@@ -8,7 +8,7 @@
 import { getLogger } from 'src/boot/pino-logger'
 import { useApi } from 'src/composables/use-api.composable'
 import { defineComponent, onMounted } from 'vue'
-import { isNavigationFailure, Router, useRoute, useRouter } from 'vue-router'
+import { isNavigationFailure, useRoute, useRouter } from 'vue-router'
 
 const LOGGER = getLogger('page:DiscordAuthCallbackPage')
 

--- a/src/pages/preview/receive/ReceiveQuickPreviewPage.vue
+++ b/src/pages/preview/receive/ReceiveQuickPreviewPage.vue
@@ -29,6 +29,7 @@ function generateErrorDialog(message = 'preview.errors.receiveEnter.generic') {
       color: 'primary',
       dense: true,
     },
+    noRouteDismiss: true,
   })
 }
 

--- a/src/route-guards/abort-on-start-location.guard.ts
+++ b/src/route-guards/abort-on-start-location.guard.ts
@@ -14,8 +14,10 @@ export const abortOnStartLocationGuard: (
 ) => NavigationHookAfter = (router) => {
   return (to, from, failure) => {
     if (
-      !isNavigationFailure(failure, NavigationFailureType.aborted) ||
-      from !== START_LOCATION
+      !(
+        isNavigationFailure(failure, NavigationFailureType.aborted) &&
+        from === START_LOCATION
+      )
     ) {
       return
     }

--- a/src/route-guards/abort-on-start-location.guard.ts
+++ b/src/route-guards/abort-on-start-location.guard.ts
@@ -7,8 +7,15 @@ import {
   Router,
 } from 'vue-router'
 
-const LOGGER = getLogger('guard:abort-on-start')
+/*
+ * This entire thing is to prevent the user from being stuck in a white-screen only page
+ * if the navigation was aborted during the starting route for the tab.
+ *
+ * If the user went to /route-1 and the `beforeRouteEnter` of the page yielded `next(false)`, if we did not
+ * have this handling, the user will only be shown a white screen.
+ */
 
+const LOGGER = getLogger('guard:abort-on-start')
 export const abortOnStartLocationGuard: (
   router: Router
 ) => NavigationHookAfter = (router) => {
@@ -22,9 +29,9 @@ export const abortOnStartLocationGuard: (
       return
     }
 
-    LOGGER.warn('Abort on START_LOCATION detected; pushing to home')
+    LOGGER.warn('Abort on START_LOCATION detected; pushing to index')
     router.push({
-      name: 'home',
+      name: 'index',
     })
   }
 }

--- a/src/route-guards/abort-on-start-location.guard.ts
+++ b/src/route-guards/abort-on-start-location.guard.ts
@@ -1,0 +1,28 @@
+import { getLogger } from 'src/boot/pino-logger'
+import {
+  isNavigationFailure,
+  NavigationFailureType,
+  NavigationHookAfter,
+  START_LOCATION,
+  Router,
+} from 'vue-router'
+
+const LOGGER = getLogger('guard:abort-on-start')
+
+export const abortOnStartLocationGuard: (
+  router: Router
+) => NavigationHookAfter = (router) => {
+  return (to, from, failure) => {
+    if (
+      !isNavigationFailure(failure, NavigationFailureType.aborted) ||
+      from !== START_LOCATION
+    ) {
+      return
+    }
+
+    LOGGER.warn('Abort on START_LOCATION detected; pushing to home')
+    router.push({
+      name: 'home',
+    })
+  }
+}

--- a/src/route-guards/session.guard.ts
+++ b/src/route-guards/session.guard.ts
@@ -5,7 +5,7 @@ import { NavigationGuard } from 'vue-router'
 
 const LOGGER = getLogger('auth-guard')
 
-export const checkSession: NavigationGuard = async (to, from, next) => {
+export const sessionGuard: NavigationGuard = async (to, from, next) => {
   const sessionStore = useSessionStore()
 
   if (to.meta.isPublicRoute) {

--- a/src/stores/server-store.ts
+++ b/src/stores/server-store.ts
@@ -19,15 +19,6 @@ export const useServerStore = defineStore('server', {
   }),
 
   actions: {
-    /**
-     * @deprecated
-     * @param id
-     * @param serverData
-     */
-    setServer(id: string, serverData: APIGuild | InaccessibleServer) {
-      this.servers[id] = serverData
-    },
-
     async fetchServer(serverId: string) {
       const inStore = this.servers[serverId]
       if (inStore) {

--- a/src/stores/server-store.ts
+++ b/src/stores/server-store.ts
@@ -1,5 +1,7 @@
 import { defineStore } from 'pinia'
 import { APIGuild } from 'discord-api-types/v10'
+import { api } from 'src/boot/axios'
+import { isAxiosError } from 'src/utils/axios.utils'
 
 export type InaccessibleServer = 'NO_ACCESS'
 
@@ -17,8 +19,33 @@ export const useServerStore = defineStore('server', {
   }),
 
   actions: {
+    /**
+     * @deprecated
+     * @param id
+     * @param serverData
+     */
     setServer(id: string, serverData: APIGuild | InaccessibleServer) {
       this.servers[id] = serverData
+    },
+
+    async fetchServer(serverId: string) {
+      const inStore = this.servers[serverId]
+      if (inStore) {
+        return inStore
+      }
+
+      try {
+        const { data } = await api.get<APIGuild>(`server/${serverId}`)
+        this.servers[serverId] = data
+        return data
+      } catch (e) {
+        if (isAxiosError(e) && e.response?.status === 403) {
+          this.servers[serverId] = 'NO_ACCESS'
+          return 'NO_ACCESS'
+        }
+
+        throw e
+      }
     },
   },
 })

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -12,10 +12,6 @@ export const useSessionStore = defineStore('session', {
   }),
 
   actions: {
-    setHasSession(value: boolean) {
-      this.hasSession = value
-    },
-
     async fetchSession() {
       if (this.hasSession !== 'UNLOADED') {
         return this.hasSession
@@ -23,11 +19,11 @@ export const useSessionStore = defineStore('session', {
 
       try {
         await api.head('session')
-        this.setHasSession(true)
+        this.hasSession = true
         return true
       } catch (e) {
         if (isAxiosError(e) && e.response?.status === 401) {
-          this.setHasSession(false)
+          this.hasSession = false
           return false
         }
 

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -12,6 +12,10 @@ export const useSessionStore = defineStore('session', {
   }),
 
   actions: {
+    setHasSession(value: boolean) {
+      this.hasSession = value
+    },
+
     async fetchSession() {
       if (this.hasSession !== 'UNLOADED') {
         return this.hasSession
@@ -19,11 +23,11 @@ export const useSessionStore = defineStore('session', {
 
       try {
         await api.head('session')
-        this.hasSession = true
+        this.setHasSession(true)
         return true
       } catch (e) {
         if (isAxiosError(e) && e.response?.status === 401) {
-          this.hasSession = false
+          this.setHasSession(false)
           return false
         }
 


### PR DESCRIPTION
* Handle cases where navigation is cancelled on the start location (i.e. directly navigated to a route, and the `beforeRouteEnter` of that route uses `next(false)`
* Handle scenario where navigation is cancelled after the OAuth callback page